### PR TITLE
SFER-120: Use length instead of width

### DIFF
--- a/SferoTestVR/Assets/Code/Scripts/Map/MapLoader.cs
+++ b/SferoTestVR/Assets/Code/Scripts/Map/MapLoader.cs
@@ -331,9 +331,9 @@ public class ExtendedRoom
             case Directon.DOWN:
                 return new Vector2(0, -room.length) + pos;
             case Directon.RIGHT:
-                return new Vector2(room.width,0) + pos;
+                return new Vector2(room.length, 0) + pos;
             case Directon.LEFT:
-                return new Vector2(-room.width, 0) + pos;
+                return new Vector2(-room.length, 0) + pos;
 
             default:
                 return new Vector2(-1,-1);


### PR DESCRIPTION
Fixed map generator.
Try testing it with long sequence of rooms. The error was in rotated rooms by 90 and 270 degrees