### PR TITLE
Fix spacebar + Emergency flags

### DIFF
--- a/SferoTestVR/Assets/Code/Scripts/Player/Player.cs
+++ b/SferoTestVR/Assets/Code/Scripts/Player/Player.cs
@@ -74,21 +74,9 @@ public class Player : MonoBehaviour
         StartCoroutine(FreezePlayer(1));
     }
 
-    /// <summary>
-    /// not modified in derived class
-    /// </summary>
-    protected virtual void FixedUpdate()
+    protected virtual void Update()
     {
-        if (playerControlsSelf)
-        {
-            GetInput();
-        }
-        else
-        {
-
-        }
-
-        if(Input.GetKeyDown(KeyCode.Space) && isAlive && !hasWon)
+        if (Input.GetKeyDown(KeyCode.Space) && isAlive && !hasWon)
         {
             Die();
         }
@@ -102,6 +90,21 @@ public class Player : MonoBehaviour
         {
             GoBackToMainMenu();
         }
+    }
+
+    /// <summary>
+    /// not modified in derived class
+    /// </summary>
+    protected virtual void FixedUpdate()
+    {
+        if (playerControlsSelf)
+        {
+            GetInput();
+        }
+        else
+        {
+
+        }        
 
         CalculateRollingVolume();
 	}

--- a/SferoTestVR/Assets/Code/Scripts/Player/PlayerVRSphere.cs
+++ b/SferoTestVR/Assets/Code/Scripts/Player/PlayerVRSphere.cs
@@ -72,6 +72,17 @@ public class PlayerVRSphere : Player
         }
     }
 
+    protected override void Update()
+    {
+        base.Update();
+
+        if (Input.GetKey(KeyCode.Space))
+        {
+            emergencyState = true;
+            Debug.Log("EMERGENCY BREAK PRESSED!!");
+        }
+    }
+
     protected override void FixedUpdate()
     {
         base.FixedUpdate();    
@@ -143,13 +154,7 @@ public class PlayerVRSphere : Player
                 //Move(sphereDirection);
             }
         }
-        //Debug.Log(GetAccumulatedTorque());
-
-        if (Input.GetKey(KeyCode.Space))
-        {
-            emergencyState = true;                
-            Debug.Log("EMERGENCY BREAK PRESSED!!");
-        }  
+        //Debug.Log(GetAccumulatedTorque());  
     }
 
     /// <summary>
@@ -204,6 +209,16 @@ public class PlayerVRSphere : Player
         }
     }
 
+
+    /// <summary>
+    /// When sphere player is revived clear the emergency flags.
+    /// </summary>
+    protected override void Revive()
+    {
+        base.Revive();
+        emergencyState = false;
+        emergencySend = false;
+    }
 
     #region Natural Movement
 


### PR DESCRIPTION
Moved keyboard input to Update - previously was in FixedUpdate, so there was quite high chance of failed space input.
Also added resetting emergency flags in revive, because otherwise it  would soft lock the game, as far as i can see.